### PR TITLE
Update PrivacyInfo.xcprivacy

### DIFF
--- a/Resources/PrivacyInfo.xcprivacy
+++ b/Resources/PrivacyInfo.xcprivacy
@@ -79,14 +79,5 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array/>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string></string>
-		</dict>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
# Remove Unneeded Key in Privacy Info
**Summary:** This PR removes an unnecessary key from the privacy information in the app configuration.

**Reason:** When integrating Kount into the app and submitting it for review in App Store Connect, the app was flagged as an invalid binary, triggering the following warning:

![image](https://github.com/user-attachments/assets/737f84c2-5163-4470-8d63-256b7edb8e0d)

**Resolution:** After removing the key, the warning no longer appears, and the app functions as expected without any issues.